### PR TITLE
Support for popping out a result

### DIFF
--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -35,7 +35,7 @@ class Router {
     return _routeTree.matchRoute(path);
   }
 
-  bool pop(BuildContext context) => Navigator.pop(context);
+  bool pop<T extends Object>(BuildContext context, [T result]) => Navigator.pop(context, result);
 
   ///
   Future navigateTo(BuildContext context, String path,


### PR DESCRIPTION
Really just a single line modification to support popping out a dynamic **result** object using **router.pop(context, result)** as with **Navigator.pop(context, result)**.