### PR TITLE
custom transitions on FluroRouter.define

### DIFF
--- a/example/lib/components/home/home_component.dart
+++ b/example/lib/components/home/home_component.dart
@@ -103,6 +103,7 @@ class HomeComponentState extends State<HomeComponent> {
       menuButton(context, "Preset (Fade In)", "preset-fade"),
       menuButton(context, "Preset (Global transition)", "fixed-trans"),
       menuButton(context, "Custom Transition", "custom"),
+      menuButton(context, "No Transition", "noTransition"),
       menuButton(context, "Navigator Result", "pop-result"),
       menuButton(context, "Function Call", "function-call"),
       new Padding(
@@ -174,6 +175,10 @@ class HomeComponentState extends State<HomeComponent> {
         message =
             "When you close this screen you should see the current day of the week";
         result = "Today is ${_daysOfWeek[new DateTime.now().weekday - 1]}!";
+      } else if (key == "noTransition") {
+        hexCode = "#9BFF94";
+        message = "This should have appeared without a transition.";
+        transitionType = TransitionType.noTransition;
       }
 
       String route = "/demo?message=$message&color_hex=$hexCode";

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -35,7 +35,14 @@ class AppRoute {
   String route;
   dynamic handler;
   TransitionType transitionType;
-  AppRoute(this.route, this.handler, {this.transitionType});
+  RouteTransitionsBuilder transitionBuilder;
+  Duration transitionDuration;
+  AppRoute(this.route, this.handler,
+      {this.transitionType,
+      this.transitionBuilder,
+      Duration transitionDuration})
+      : this.transitionDuration =
+            transitionDuration ?? const Duration(milliseconds: 250);
 }
 
 enum TransitionType {

--- a/lib/src/common.dart
+++ b/lib/src/common.dart
@@ -45,6 +45,7 @@ enum TransitionType {
   inFromRight,
   inFromBottom,
   fadeIn,
+  noTransition,
   custom, // if using custom then you must also provide a transition
 }
 

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -134,6 +134,8 @@ class Router {
         var routeTransitionsBuilder;
         if (transition == TransitionType.custom) {
           routeTransitionsBuilder = transitionsBuilder;
+        } else if (transition == TransitionType.noTransition) {
+          routeTransitionsBuilder = _noTransitionBuilder(transition);
         } else {
           routeTransitionsBuilder = _standardTransitionsBuilder(transition);
         }
@@ -152,6 +154,13 @@ class Router {
       matchType: RouteMatchType.visual,
       route: creator(settingsToUse, parameters),
     );
+  }
+
+  RouteTransitionsBuilder _noTransitionBuilder(TransitionType transitionType) {
+    return (BuildContext context, Animation<double> animation,
+        Animation<double> secondaryAnimation, Widget child) {
+      return child;
+    };
   }
 
   RouteTransitionsBuilder _standardTransitionsBuilder(

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -24,9 +24,17 @@ class Router {
 
   /// Creates a [PageRoute] definition for the passed [RouteHandler]. You can optionally provide a default transition type.
   void define(String routePath,
-      {@required Handler handler, TransitionType transitionType}) {
-    _routeTree.addRoute(
-        new AppRoute(routePath, handler, transitionType: transitionType));
+      {@required Handler handler,
+      TransitionType transitionType,
+      RouteTransitionsBuilder transitionBuilder,
+      Duration transitionDuration}) {
+    _routeTree.addRoute(new AppRoute(
+      routePath,
+      handler,
+      transitionType: transitionType,
+      transitionBuilder: transitionBuilder,
+      transitionDuration: transitionDuration,
+    ));
   }
 
   /// Finds a defined [AppRoute] for the path value. If no [AppRoute] definition was found
@@ -102,6 +110,11 @@ class Router {
     }
     AppRouteMatch match = _routeTree.matchRoute(path);
     AppRoute route = match?.route;
+
+    if (route.transitionDuration != null) {
+      transitionDuration = route.transitionDuration;
+    }
+
     Handler handler = (route != null ? route.handler : notFoundHandler);
     var transition = transitionType;
     if (transitionType == null) {
@@ -133,7 +146,11 @@ class Router {
       } else {
         var routeTransitionsBuilder;
         if (transition == TransitionType.custom) {
-          routeTransitionsBuilder = transitionsBuilder;
+          if (route.transitionBuilder != null) {
+            routeTransitionsBuilder = route.transitionBuilder;
+          } else {
+            routeTransitionsBuilder = transitionsBuilder;
+          }
         } else if (transition == TransitionType.noTransition) {
           routeTransitionsBuilder = _noTransitionBuilder(transition);
         } else {


### PR DESCRIPTION
This PR adds the ability to define custom transitions like this:

```dart
void defineRoutes(Router router) {
  router.define("/users/:id", handler: usersHandler, transitionType: TransitionType.custom, transitionBuilder: yourCustomTransitionBuilder, transitionDuration: Duration(milliseconds: 500));
}
```

Previously, setting the custom transition builder was only possible on navigation. From the examples:
```dart
Application.router.navigateTo(
        context,
        "/demo?message=$message&color_hex=$hexCode",
        transition: TransitionType.custom,
        transitionBuilder: transition,
        transitionDuration: const Duration(milliseconds: 600),
      );
```