### PR TITLE
Fix null BuildContext

### DIFF
--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -218,9 +218,9 @@ class Router {
   /// Route generation method. This function can be used as a way to create routes on-the-fly
   /// if any defined handler is found. It can also be used with the [MaterialApp.onGenerateRoute]
   /// property as callback to create routes that can be used with the [Navigator] class.
-  Route<dynamic> generator(RouteSettings routeSettings) {
+  Route<dynamic> generator(BuildContext context, RouteSettings routeSettings) {
     RouteMatch match =
-        matchRoute(null, routeSettings.name, routeSettings: routeSettings);
+        matchRoute(context, routeSettings.name, routeSettings: routeSettings);
     return match.route;
   }
 


### PR DESCRIPTION
fixes #154.

This is a breaking change and will require a switch from this...

```dart
MaterialApp(
  title: 'My App',
  initialRoute: '/',
  onGenerateRoute: myRouter.generator,
);
```

...to this

```dart
MaterialApp(
  title: 'My App',
  initialRoute: '/',
  onGenerateRoute: (routeSettings) =>
      myRouter.generator(context, routeSettings),
);
```

There may be a better way to fix this.

Thoughts?