### PR TITLE
allow GlobalKey use

### DIFF
--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -16,7 +16,12 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class Router {
+  Router({this.navigatorKey});
+
   static final appRouter = Router();
+
+  // The GlobalKey which controlls routing from outside (not using Navigator directory).
+  final GlobalKey<NavigatorState> navigatorKey;
 
   /// The tree structure that stores the defined routes
   final RouteTree _routeTree = RouteTree();
@@ -38,7 +43,9 @@ class Router {
     return _routeTree.matchRoute(path);
   }
 
-  void pop(BuildContext context) => Navigator.pop(context);
+  void pop(BuildContext context) => navigatorKey == null
+      ? Navigator.pop(context)
+      : navigatorKey.currentState.pop();
 
   ///
   Future navigateTo(BuildContext context, String path,
@@ -62,12 +69,18 @@ class Router {
       }
       if (route != null) {
         if (clearStack) {
-          future =
-              Navigator.pushAndRemoveUntil(context, route, (check) => false);
+          future = navigatorKey == null
+              ? Navigator.pushAndRemoveUntil(context, route, (check) => false)
+              : navigatorKey.currentState
+                  .pushAndRemoveUntil(route, (check) => false);
         } else {
           future = replace
-              ? Navigator.pushReplacement(context, route)
-              : Navigator.push(context, route);
+              ? navigatorKey == null
+                  ? Navigator.pushReplacement(context, route)
+                  : navigatorKey.currentState.pushReplacement(route)
+              : navigatorKey == null
+                  ? Navigator.push(context, route)
+                  : navigatorKey.currentState.push(route);
         }
         completer.complete();
       } else {

--- a/lib/src/router.dart
+++ b/lib/src/router.dart
@@ -43,6 +43,10 @@ class Router {
     return _routeTree.matchRoute(path);
   }
 
+  bool canPop(BuildContext context) => navigatorKey == null
+      ? Navigator.canPop(context)
+      : navigatorKey.currentState.canPop();
+
   void pop(BuildContext context) => navigatorKey == null
       ? Navigator.pop(context)
       : navigatorKey.currentState.pop();


### PR DESCRIPTION
It looks like using Navigator directory and does not accept GlobalKey of NavigatorState as argument.
However, my application controls routing from outside of the widget tree which has a Navigator as the ancestor.

like this.

```dart
    return Stack(
      children: <Widget>[
        Navigator(
          key: navigatorKey,  <= I need it.
          initialRoute: _initialRoute(context),
          onGenerateRoute: ...
        ),
        Align(
          alignment: Alignment.bottomCenter,
          child: ... <= use the navigator key here to change routing
        ),
      ],
    );
```

I added optional field to keep navigatorKey and use whenever change routes (pop, replace, push).