### PR TITLE
Use MaterialPageRoute for all platforms when using TransitionType.native

### DIFF
--- a/lib/src/fluro_router.dart
+++ b/lib/src/fluro_router.dart
@@ -164,23 +164,13 @@ class FluroRouter {
       bool isNativeTransition = (transition == TransitionType.native ||
           transition == TransitionType.nativeModal);
       if (isNativeTransition) {
-        if (Theme.of(buildContext).platform == TargetPlatform.iOS) {
-          return CupertinoPageRoute<dynamic>(
-              settings: routeSettings,
-              fullscreenDialog: transition == TransitionType.nativeModal,
-              maintainState: maintainState,
-              builder: (BuildContext context) {
-                return handler.handlerFunc(context, parameters);
-              });
-        } else {
-          return MaterialPageRoute<dynamic>(
-              settings: routeSettings,
-              fullscreenDialog: transition == TransitionType.nativeModal,
-              maintainState: maintainState,
-              builder: (BuildContext context) {
-                return handler.handlerFunc(context, parameters);
-              });
-        }
+        return MaterialPageRoute<dynamic>(
+            settings: routeSettings,
+            fullscreenDialog: transition == TransitionType.nativeModal,
+            maintainState: maintainState,
+            builder: (BuildContext context) {
+              return handler.handlerFunc(context, parameters);
+            });
       } else if (transition == TransitionType.material ||
           transition == TransitionType.materialFullScreenDialog) {
         return MaterialPageRoute<dynamic>(


### PR DESCRIPTION
This removes checking the platform and pushing [CupertinoPageRoute](https://api.flutter.dev/flutter/cupertino/CupertinoPageRoute-class.html) on iOS and [MaterialPageRoute](https://api.flutter.dev/flutter/material/MaterialPageRoute-class.html) on Android, and instead only uses MaterialPageRoute.

This still maintains the native transitions on iOS and Android, because MaterialPageRoute itself is platform-aware:

>A modal route that replaces the entire screen with a **platform-adaptive transition**.
>
>For Android, the entrance transition for the page slides the route upwards and fades it in. The exit transition is the same, but in reverse.
>
>The transition is adaptive to the platform and on iOS, the route slides in from the right and exits in reverse. The route also shifts to the left in parallax when another page enters to cover it. (These directions are flipped in environments with a right-to-left reading direction.)

Tested using:
- iOS 14.0, 14.1, and 14.2
- Android 9, 10, and 11
- Dart 2.10.2
- Flutter stable channel, latest release at time of writing (1.22.2 revision 84f3d28555)

This however was not tested on Flutter web, but I can't imagine it would cause any issues.

This fixes #154.