### PR TITLE
fix: respect transitionDuration in navigateTo()

### DIFF
--- a/lib/src/fluro_router.dart
+++ b/lib/src/fluro_router.dart
@@ -135,7 +135,7 @@ class FluroRouter {
     AppRouteMatch? match = _routeTree.matchRoute(path!);
     AppRoute? route = match?.route;
 
-    if (route?.transitionDuration != null) {
+    if (transitionDuration == null && route?.transitionDuration != null) {
       transitionDuration = route?.transitionDuration;
     }
 


### PR DESCRIPTION
It was applying the default route's transitionDuration to any navigateTo(), even if another value was passed.
Now, it will apply the default value only if a transitionDuration was not passed.