### PR TITLE
Added allow null to handler example for build context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ you can access the router in other areas in your application.
 After instantiating the router, you will need to define your routes and your route handlers:
 
 ```dart
-var usersHandler = Handler(handlerFunc: (BuildContext context, Map<String, dynamic> params) {
+var usersHandler = Handler(handlerFunc: (BuildContext? context, Map<String, dynamic> params) {
   return UsersScreen(params["id"][0]);
 });
 


### PR DESCRIPTION
As seen in [issue 240](https://github.com/lukepighetti/fluro/issues/240) the example misses the allow null operator for the buildcontext parameter creating some confusion.