### PR TITLE
Add predicate parameters to the navigateTo method.

### DIFF
--- a/lib/src/fluro_router.dart
+++ b/lib/src/fluro_router.dart
@@ -69,12 +69,14 @@ class FluroRouter {
     String path, {
     bool replace = false,
     bool clearStack = false,
+    bool isPushAndRemove = false,
     bool maintainState = true,
     bool rootNavigator = false,
     TransitionType? transition,
     Duration? transitionDuration,
     RouteTransitionsBuilder? transitionBuilder,
     RouteSettings? routeSettings,
+    RoutePredicate? predicate,
   }) {
     RouteMatch routeMatch = matchRoute(
       context,
@@ -99,8 +101,14 @@ class FluroRouter {
 
       if (route != null) {
         final navigator = Navigator.of(context, rootNavigator: rootNavigator);
-        if (clearStack) {
-          future = navigator.pushAndRemoveUntil(route, (check) => false);
+        if (clearStack) isPushAndRemove = true;
+        if (isPushAndRemove && predicate == null) clearStack = true;
+
+        if (isPushAndRemove) {
+          future = navigator.pushAndRemoveUntil(
+            route,
+            clearStack ? (check) => false : predicate!,
+          );
         } else {
           future = replace
               ? navigator.pushReplacement(route)


### PR DESCRIPTION
Two parameters [isPushAndRemove] and [predicate] have been added to [FluroRouter.navigateTo] so that users can customize [RoutePredicate].

e.g. Avoid opening the same page (the scenario is as follows: when multiple network requests fail, the reason is that the network disconnects and the network error page needs to be opened, but avoids repeated opening)
``` dart
router.navigateTo(
  context,
  Routes.networkErrorPage,
  isPushAndRemove: true,
  predicate: (route) =>
      route.isCurrent && route.settings.name == Routes.networkErrorPage
          ? false
          : true,
);
```